### PR TITLE
fix: landscape mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can check out the package's [CHANGELOG.md](./CHANGELOG.md) file.
 
 ### Progress
 
-You can also checkout the project's [roadmap](#).
+You can also checkout the project's [roadmap](https://github.com/users/GoodM4ven/projects/4/).
 
 
 ## Support

--- a/lib/helpers/size.dart
+++ b/lib/helpers/size.dart
@@ -19,17 +19,32 @@ class HelperSize {
         viewPadding.right > 0;
   }
 
-  static bool isLessThanMinimumScreen(BuildContext context) {
+  static bool isInLandscapeMobileScreen(BuildContext context) {
+    return hasScreenSafeArea(context) &&
+        MediaQuery.of(context).orientation == Orientation.landscape;
+  }
+
+  static bool hasLessThanMinimumScreen(BuildContext context) {
     final Size screenSize = MediaQuery.of(context).size;
+
+    if (isInLandscapeMobileScreen(context)) {
+      return screenSize.width < minScreenHeight ||
+          screenSize.height < minScreenWidth;
+    }
 
     return screenSize.width < minScreenWidth ||
         screenSize.height < minScreenHeight;
   }
 
-  static bool isNearMinimumScreen(BuildContext context) {
+  static bool hasNearMinimumScreen(BuildContext context) {
     const nearMinWidth = minScreenWidth + 100;
     const nearMinHeight = minScreenHeight + 100;
     final Size screenSize = MediaQuery.of(context).size;
+
+    if (isInLandscapeMobileScreen(context)) {
+      return screenSize.width <= nearMinHeight ||
+          screenSize.height <= nearMinWidth;
+    }
 
     return screenSize.width <= nearMinWidth ||
         screenSize.height <= nearMinHeight;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -44,7 +44,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
 
     // * Crash for less than minimum screens
-    if (HelperSize.isLessThanMinimumScreen(context)) {
+    if (HelperSize.hasLessThanMinimumScreen(context)) {
       return const LessThanMinimumScreensScaffoldWidget();
     }
 

--- a/lib/views/bookmarks_view.dart
+++ b/lib/views/bookmarks_view.dart
@@ -165,7 +165,7 @@ class _BookmarksViewState extends State<BookmarksView>
                           gridDelegate:
                               SliverGridDelegateWithMaxCrossAxisExtent(
                             mainAxisExtent:
-                                HelperSize.isNearMinimumScreen(context)
+                                HelperSize.hasNearMinimumScreen(context)
                                     ? 75
                                     : 50,
                             maxCrossAxisExtent: 400,
@@ -201,9 +201,9 @@ class _BookmarksViewState extends State<BookmarksView>
                                 title: Padding(
                                   padding: const EdgeInsets.only(bottom: 8.0),
                                   child: Text(
-                                    "${pair.first}${HelperSize.isNearMinimumScreen(context) ? '\n' : ''}${HelperString.toTitleCase(pair.second)}",
+                                    "${pair.first}${HelperSize.hasNearMinimumScreen(context) ? '\n' : ''}${HelperString.toTitleCase(pair.second)}",
                                     softWrap:
-                                        HelperSize.isNearMinimumScreen(context),
+                                        HelperSize.hasNearMinimumScreen(context),
                                     semanticsLabel: pair.asPascalCase,
                                     style: const TextStyle(
                                       fontSize: 20,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "A paired-name generator app."
 
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   sdk: ^3.5.2


### PR DESCRIPTION
In landscape mode for mobile screens, the app activates the safe mode warning against "small screens".

It's happening because the previous logic wasn't being respected (flipped) when dealing with landscape orientation for some reason. So a manual flip had to be applied!